### PR TITLE
Config update

### DIFF
--- a/docs/htmap/config.md
+++ b/docs/htmap/config.md
@@ -4,11 +4,10 @@ title: Config
 sidebar_label: Config
 ---
 ___
-Config files can make your plugin one of the most customisablest in the world! But to use a config file, we need multiple things:  
-1. A default config file, saved on a resource folder
-2. Saving the config so the user can edit it
-3. Taking data from the config
-4. Setting data to the config  
+Config files can make your plugin one of the most customisable in the world! Using a config file can be split into 3 topics:  
+1. Saving default config
+2. Getting data from the config
+3. Setting data to the config  
 
 ## 1- Creating a default config:  
 
@@ -17,34 +16,28 @@ Go to your root plugin folder and create a folder called "resources".
 Inside of it, create a file "config.yml" and put the default config you want to display to the user.  
 
 Yaml works like array:   
-```
-        key: value
+```yaml
+    key: value
 ``` 
-## 2- Saving the config:
-Saving the config when the plugins enables after you succefully made your config, go to your main file and add to your onEnable function:
-```php
-    $this->saveDefaultConfig(); // Saves config.yml if not created.
-    $this->reloadConfig(); // Reloads the config.yml file internally
-```
-## 3- Taking data from the config: 
+## 2- Taking data from the config: 
 
 If you wanna get the data from your config, add this line:      
 ```php
     $keyFromConfig = $this->getConfig()->get("key"); // This will return the element "key" from the config.
-```       
-Its also a good practive to reload your config before to be sure to get the last user choice.  
+```
+You can also reload your config before if you want to get any config options that have been changed during runtime.
 ```php
     $this->reloadConfig();
 ```
-## 4- Setting data to the config: 
+## 3- Setting data to the config: 
 
-Setting data to the config helps you to save data for games, or to correct wrong values inputed by the user.  
+Setting data to the config helps you to correct wrong values inputed by the user.
 
 To set data to the config, add this line to your code when you want to set the data to the config.  
 ```php
-    $this->getConfig()->set("key", "example"); // This will set the element "key" of the config.to example.
+    $this->getConfig()->set("key", "example"); // This will set the element "key" of the config to "example".
 ```
 But remember that you need to save the config to apply changes in the file.  
 ```php
-    $this->getConfig()->save(); // Saves the config
+    $this->saveConfig();
 ```


### PR DESCRIPTION
- Saving config, reloading config on enable is completely useless as pocketmine does this when you first getConfig()
- `Setting data to the config helps you to save data for games` Is very vague and you **don't** want people to save game data to a configuration file, use a database or anything BUT the config file.
- `$this->getConfig()->save()` can be shortened and better handled with `$this->saveConfig()`